### PR TITLE
Fixes Dungeon to Dungeon Stacking

### DIFF
--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -284,6 +284,17 @@ public:
             }
         }
     }
+	
+	    void OnLogout(Player* player)
+    {
+		//Database query to see if an entry is still there
+		QueryResult result = CharacterDatabase.PQuery("SELECT `GUID` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+		if (result)
+		{
+			//Remove database entry as the player has logged out
+			CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+		}
+    }	
 };
 class solocraft_player_instance_handler : public PlayerScript {
 public:
@@ -391,9 +402,17 @@ private:
                     difficulty = difficulty / numInGroup;
                     difficulty = roundf(difficulty * 100) / 100; //Float variables suck - two decimal rounding
                 }
+				
+				//Check Database for a current dungeon entry
+				QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+
                 //Modify Player Stats
                 for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i) //STATS defined/enum in SharedDefines.h
                 {
+					if (result) 
+					{	
+						player->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
+					}
                     // Buff the player
                     player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, difficulty * SoloCraftStatsMult, true); //Unitmods enum UNIT_MOD_STAT_START defined in Unit.h line 391
                 }
@@ -404,6 +423,14 @@ private:
                 {
                     // Buff the player's mana
                     player->SetPower(POWER_MANA, player->GetMaxPower(POWER_MANA));
+										
+					//Check for Dungeon to Dungeon Transfer and remove old Spellpower buff					
+					if (result) 
+					{					
+						// remove spellpower bonus
+						player->ApplySpellPowerBonus((*result)[3].GetUInt32() * (*result)[4].GetFloat(),false);	
+					}	
+					
                     //Buff Spellpower
                     if (difficulty > 0) //Debuffed characters do not get spellpower
                     {
@@ -433,11 +460,16 @@ private:
                 // Announce to player - Over Max Level Threshold
                 ss << "|cffFF0000[SoloCraft] |cffFF8000" << player->GetName() << " entered %s  - |cffFF0000You have not been buffed. |cffFF8000 Your level is higher than the max level (%i) threshold for this dungeon.";
                 ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), dunLevel + SolocraftLevelDiff);
-            }
-        }
-        else
-            ClearBuffs(player, map); //Check to revert player back to normal - Moving this here fixed logout and login while in instance buff and debuff issues
-    }
+				ClearBuffs(player, map); //Check to revert player back to normal
+			}
+			
+		}
+		else
+		{
+			ClearBuffs(player, map); //Check to revert player back to normal - Moving this here fixed logout and login while in instance buff and debuff issues
+		}
+	}
+	
     // Get the current group members GUIDS and return the total sum of the difficulty offset by all group members currently in the dungeon
     float GetGroupDifficulty(Player* player) {
         float GroupDifficulty = 0.0;

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -411,7 +411,7 @@ private:
                 {
 					if (result) 
 					{	
-						player->HandleStatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
+						player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
 					}
                     // Buff the player
                     player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, difficulty * SoloCraftStatsMult, true); //Unitmods enum UNIT_MOD_STAT_START defined in Unit.h line 391

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -288,7 +288,7 @@ public:
     void OnLogout(Player* player) override
     {
         //Remove database entry as the player has logged out
-        CharacterDatabase.PQuery("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+        CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
     }
 };
 class solocraft_player_instance_handler : public PlayerScript {
@@ -400,7 +400,7 @@ private:
                 }
 
                 //Check Database for a current dungeon entry
-                QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+                QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
 
                 //Modify Player Stats
                 for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i) //STATS defined/enum in SharedDefines.h
@@ -449,7 +449,7 @@ private:
                     ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), difficulty);
                 }
                 // Save Player Dungeon Offsets to Database
-                CharacterDatabase.PQuery("REPLACE INTO custom_solocraft_character_stats (GUID, Difficulty, GroupSize, SpellPower, Stats) VALUES (%u, %f, %u, %i, %f)", player->GetGUID(), difficulty, numInGroup, SpellPowerBonus, SoloCraftStatsMult);
+                CharacterDatabase.PExecute("REPLACE INTO custom_solocraft_character_stats (GUID, Difficulty, GroupSize, SpellPower, Stats) VALUES (%u, %f, %u, %i, %f)", player->GetGUID(), difficulty, numInGroup, SpellPowerBonus, SoloCraftStatsMult);
             }
             else
             {
@@ -479,7 +479,7 @@ private:
                 if (itr->guid != player->GetGUID())
                 {
                     //Database query to find difficulty for each group member that is currently in an instance
-                    QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = %u", itr->guid);
+                    QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = %u", itr->guid);
                     if (result)
                     {
                         //Test for debuffs already give to other members - They cannot be used to determine the total offset because negative numbers will skew the total difficulty offset
@@ -498,7 +498,7 @@ private:
     void ClearBuffs(Player* player, Map* map)
     {
         //Database query to get offset from the last instance player exited
-        QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+        QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
         if (result)
         {
             float difficulty = (*result)[1].GetFloat();
@@ -520,7 +520,7 @@ private:
                 player->ApplySpellPowerBonus(SpellPowerBonus, false);
             }
             //Remove database entry as the player is no longer in an instance
-            CharacterDatabase.PQuery("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+            CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
         }
     }
 };

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -288,7 +288,7 @@ public:
     void OnLogout(Player* player) override
     {
         //Remove database entry as the player has logged out
-        CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+        CharacterDatabase.PQuery("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
     }
 };
 class solocraft_player_instance_handler : public PlayerScript {
@@ -449,7 +449,7 @@ private:
                     ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), difficulty);
                 }
                 // Save Player Dungeon Offsets to Database
-                CharacterDatabase.PExecute("REPLACE INTO custom_solocraft_character_stats (GUID, Difficulty, GroupSize, SpellPower, Stats) VALUES (%u, %f, %u, %i, %f)", player->GetGUID(), difficulty, numInGroup, SpellPowerBonus, SoloCraftStatsMult);
+                CharacterDatabase.PQuery("REPLACE INTO custom_solocraft_character_stats (GUID, Difficulty, GroupSize, SpellPower, Stats) VALUES (%u, %f, %u, %i, %f)", player->GetGUID(), difficulty, numInGroup, SpellPowerBonus, SoloCraftStatsMult);
             }
             else
             {
@@ -520,7 +520,7 @@ private:
                 player->ApplySpellPowerBonus(SpellPowerBonus, false);
             }
             //Remove database entry as the player is no longer in an instance
-            CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+            CharacterDatabase.PQuery("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
         }
     }
 };

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -284,16 +284,16 @@ public:
             }
         }
     }
-	
-	    void OnLogout(Player* player)
+
+    void OnLogout(Player* player) override
     {
-		//Database query to see if an entry is still there
-		QueryResult result = CharacterDatabase.PQuery("SELECT `GUID` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
-		if (result)
-		{
-			//Remove database entry as the player has logged out
-			CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
-		}
+        //Database query to see if an entry is still there
+        QueryResult result = CharacterDatabase.PQuery("SELECT `GUID` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+        if (result)
+        {
+        	//Remove database entry as the player has logged out
+        	CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+        }
     }	
 };
 class solocraft_player_instance_handler : public PlayerScript {
@@ -309,6 +309,7 @@ public:
             ApplyBuffs(player, map, difficulty, dunLevel, numInGroup);
         }
     }
+
 private:
     std::map<uint32, float> _unitDifficulty;
     // Set the instance difficulty
@@ -402,17 +403,17 @@ private:
                     difficulty = difficulty / numInGroup;
                     difficulty = roundf(difficulty * 100) / 100; //Float variables suck - two decimal rounding
                 }
-				
-				//Check Database for a current dungeon entry
-				QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+
+                //Check Database for a current dungeon entry
+                QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
 
                 //Modify Player Stats
                 for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i) //STATS defined/enum in SharedDefines.h
                 {
-					if (result) 
-					{	
-						player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_PCT, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
-					}
+                    if (result) 
+                    {	
+                    	player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
+                    }
                     // Buff the player
                     player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, difficulty * SoloCraftStatsMult, true); //Unitmods enum UNIT_MOD_STAT_START defined in Unit.h line 391
                 }
@@ -423,14 +424,14 @@ private:
                 {
                     // Buff the player's mana
                     player->SetPower(POWER_MANA, player->GetMaxPower(POWER_MANA));
-										
-					//Check for Dungeon to Dungeon Transfer and remove old Spellpower buff					
-					if (result) 
-					{					
-						// remove spellpower bonus
-						player->ApplySpellPowerBonus((*result)[3].GetUInt32() * (*result)[4].GetFloat(),false);	
-					}	
-					
+
+                    //Check for Dungeon to Dungeon Transfer and remove old Spellpower buff
+                    if (result) 
+                    {
+                        // remove spellpower bonus
+                        player->ApplySpellPowerBonus((*result)[3].GetUInt32() * (*result)[4].GetFloat(),false);	
+                    }
+
                     //Buff Spellpower
                     if (difficulty > 0) //Debuffed characters do not get spellpower
                     {
@@ -460,16 +461,16 @@ private:
                 // Announce to player - Over Max Level Threshold
                 ss << "|cffFF0000[SoloCraft] |cffFF8000" << player->GetName() << " entered %s  - |cffFF0000You have not been buffed. |cffFF8000 Your level is higher than the max level (%i) threshold for this dungeon.";
                 ChatHandler(player->GetSession()).PSendSysMessage(ss.str().c_str(), map->GetMapName(), dunLevel + SolocraftLevelDiff);
-				ClearBuffs(player, map); //Check to revert player back to normal
-			}
-			
-		}
-		else
-		{
-			ClearBuffs(player, map); //Check to revert player back to normal - Moving this here fixed logout and login while in instance buff and debuff issues
-		}
-	}
-	
+                ClearBuffs(player, map); //Check to revert player back to normal
+            }
+
+        }
+        else
+        {
+            ClearBuffs(player, map); //Check to revert player back to normal - Moving this here fixed logout and login while in instance buff and debuff issues
+        }
+    }
+
     // Get the current group members GUIDS and return the total sum of the difficulty offset by all group members currently in the dungeon
     float GetGroupDifficulty(Player* player) {
         float GroupDifficulty = 0.0;
@@ -498,6 +499,7 @@ private:
         }
         return GroupDifficulty;
     }
+
     void ClearBuffs(Player* player, Map* map)
     {
         //Database query to get offset from the last instance player exited

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -410,7 +410,7 @@ private:
                 //Modify Player Stats
                 for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i) //STATS defined/enum in SharedDefines.h
                 {
-                    if (result) 
+                    if (result)
                     {
                         player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
                     }
@@ -426,7 +426,7 @@ private:
                     player->SetPower(POWER_MANA, player->GetMaxPower(POWER_MANA));
 
                     //Check for Dungeon to Dungeon Transfer and remove old Spellpower buff
-                    if (result) 
+                    if (result)
                     {
                         // remove spellpower bonus
                         player->ApplySpellPowerBonus((*result)[3].GetUInt32() * (*result)[4].GetFloat(),false);

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -287,13 +287,8 @@ public:
 
     void OnLogout(Player* player) override
     {
-        //Database query to see if an entry is still there
-        QueryResult result = CharacterDatabase.PQuery("SELECT `GUID` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
-        if (result)
-        {
-            //Remove database entry as the player has logged out
-            CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
-        }
+        //Remove database entry as the player has logged out
+        CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
     }
 };
 class solocraft_player_instance_handler : public PlayerScript {

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -400,7 +400,7 @@ private:
                 }
 
                 //Check Database for a current dungeon entry
-                QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+                QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
 
                 //Modify Player Stats
                 for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i) //STATS defined/enum in SharedDefines.h
@@ -479,7 +479,7 @@ private:
                 if (itr->guid != player->GetGUID())
                 {
                     //Database query to find difficulty for each group member that is currently in an instance
-                    QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = %u", itr->guid);
+                    QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = %u", itr->guid);
                     if (result)
                     {
                         //Test for debuffs already give to other members - They cannot be used to determine the total offset because negative numbers will skew the total difficulty offset

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -498,7 +498,7 @@ private:
     void ClearBuffs(Player* player, Map* map)
     {
         //Database query to get offset from the last instance player exited
-        QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
+        QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize`, `SpellPower`, `Stats` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
         if (result)
         {
             float difficulty = (*result)[1].GetFloat();

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -479,7 +479,7 @@ private:
                 if (itr->guid != player->GetGUID())
                 {
                     //Database query to find difficulty for each group member that is currently in an instance
-                    QueryResult result = CharacterDatabase.PExecute("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = %u", itr->guid);
+                    QueryResult result = CharacterDatabase.PQuery("SELECT `GUID`, `Difficulty`, `GroupSize` FROM `custom_solocraft_character_stats` WHERE GUID = %u", itr->guid);
                     if (result)
                     {
                         //Test for debuffs already give to other members - They cannot be used to determine the total offset because negative numbers will skew the total difficulty offset

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -291,10 +291,10 @@ public:
         QueryResult result = CharacterDatabase.PQuery("SELECT `GUID` FROM `custom_solocraft_character_stats` WHERE GUID = %u", player->GetGUID());
         if (result)
         {
-        	//Remove database entry as the player has logged out
-        	CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
+            //Remove database entry as the player has logged out
+            CharacterDatabase.PExecute("DELETE FROM custom_solocraft_character_stats WHERE GUID = %u", player->GetGUID());
         }
-    }	
+    }
 };
 class solocraft_player_instance_handler : public PlayerScript {
 public:
@@ -411,8 +411,8 @@ private:
                 for (int32 i = STAT_STRENGTH; i < MAX_STATS; ++i) //STATS defined/enum in SharedDefines.h
                 {
                     if (result) 
-                    {	
-                    	player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
+                    {
+                        player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, (*result)[1].GetFloat() * (*result)[4].GetFloat(), false);
                     }
                     // Buff the player
                     player->HandleStatFlatModifier(UnitMods(UNIT_MOD_STAT_START + i), TOTAL_VALUE, difficulty * SoloCraftStatsMult, true); //Unitmods enum UNIT_MOD_STAT_START defined in Unit.h line 391
@@ -429,7 +429,7 @@ private:
                     if (result) 
                     {
                         // remove spellpower bonus
-                        player->ApplySpellPowerBonus((*result)[3].GetUInt32() * (*result)[4].GetFloat(),false);	
+                        player->ApplySpellPowerBonus((*result)[3].GetUInt32() * (*result)[4].GetFloat(),false);
                     }
 
                     //Buff Spellpower


### PR DESCRIPTION
Going from one dungeon id immediately to another dungeon id would stack the effects. This corrects that

**Target branch(es)**: 335 Solocraft

**Issues addressed**: Fixes Dungeon to Dungeon Stacking, If you move from one instance to another, the scaling would of stacked.

**Tests performed**: Build and plays

