### PR TITLE
Updated Incl Dir of Config.h

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -48,6 +48,7 @@
 #include "CombatPackets.h"
 #include "Common.h"
 #include "ConditionMgr.h"
+#include "Config.h"
 #include "CreatureAI.h"
 #include "DatabaseEnv.h"
 #include "DisableMgr.h"


### PR DESCRIPTION
To avoid patche conflicts utilizing the same placement of config.h.
Currently with patch appliers of the dynamic resurrection and the AOE Looting gets a conflict of the config.h even though its in the same exact spot on both.

**Changes proposed**:

Add config.h incl dir

**Target branch(es)**: 335

**Issues addressed**: To avoid patche conflicts utilizing the same placement of config.h.
Currently with patch appliers of the dynamic resurrection and the AOE Looting gets a conflict of the config.h even though its in the same exact spot on both.

**Tests performed**: Builds and plays.
