### PR TITLE
Item looting from inventory crash fix

### DIFF
--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -81,7 +81,7 @@ void WorldSession::HandleAutostoreLootItemOpcode(WorldPacket& recvData)
     else
     {
         Creature* creature = GetPlayer()->GetMap()->GetCreature(lguid);
-        if (!player->GetGroup() && sConfigMgr->GetBoolDefault("AOE.LOOT.enable", true))
+        if (!player->GetGroup() && creature && sConfigMgr->GetBoolDefault("AOE.LOOT.enable", true))
         {
             int i = 0;
             float range = 30.0f;
@@ -244,7 +244,9 @@ void WorldSession::HandleLootMoneyOpcode(WorldPacket& /*recvData*/)
         }
         else
         {
-            if (sConfigMgr->GetBoolDefault("AOE.LOOT.enable", true))
+            ObjectGuid lguid = player->GetLootGUID();
+            Creature* creature = GetPlayer()->GetMap()->GetCreature(lguid);
+            if (creature && sConfigMgr->GetBoolDefault("AOE.LOOT.enable", true))
             {
                 if (!player->GetGroup())
                 {


### PR DESCRIPTION
**Changes proposed**:

Fixes crashing when looting item from a item from player's inventory.

**Target branch(es)**: 335

**Issues addressed**: Fixes Crashing when looting a item container from player inventory

**Tests performed**: Tested and no longer crashes when looting item from a item from player's inventory and also previous testing when dealing with raids, dungeons, bosses, skinning, mechnical skinng shows no crash as well.

