### PR TITLE
Feat: (Solocraft) Add Solocraft Class Balance Modifier

### DIFF
--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -419,7 +419,7 @@ private:
         {
             return classBalance; //class not found returns the catch all value
         }
-        else if (classes[player->GetClass()] >= 0 && classes[player->GetClass()] <= 100)
+        else if (classes[player->GetClass()] <= 100)
         {
             return classes[player->GetClass()]; //return the specific class's Balance value
         }

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -332,7 +332,7 @@ public:
             float difficulty = CalculateDifficulty(map, player);
             int dunLevel = CalculateDungeonLevel(map, player);
             int numInGroup = GetNumInGroup(player);
-            int classBalance = GetClassBalance(player);
+            uint32 classBalance = GetClassBalance(player);
             ApplyBuffs(player, map, difficulty, dunLevel, numInGroup, classBalance);
         }
     }
@@ -403,9 +403,9 @@ private:
         return numInGroup;
     }
     // Get the Player's class balance debuff
-    int GetClassBalance(Player* player)
+    uint32 GetClassBalance(Player* player)
     {
-        int classBalance = 100;
+        uint32 classBalance = 100;
 
         if (classes.find(player->GetClass()) == classes.end())
         {

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -351,7 +351,8 @@ private:
                 if (map->IsHeroic() && map->GetId() == 649) {
                     return D649H25;  //Heroic Grand Trial of the Crusader
                 }
-                else if (diff_Multiplier_Heroics.find(map->GetId()) == diff_Multiplier_Heroics.end()) {
+                else if (diff_Multiplier_Heroics.find(map->GetId()) == diff_Multiplier_Heroics.end())
+                {
                     return D25; //map not found returns the catch all value
                 }
                 else
@@ -360,21 +361,26 @@ private:
             if (map->IsHeroic())
             {
                 //WOTLK 10 Man Heroic
-                if (map->GetId() == 649) {
+                if (map->GetId() == 649)
+                {
                     return D649H10;
                 }
-                else if (diff_Multiplier_Heroics.find(map->GetId()) == diff_Multiplier_Heroics.end()) {
+                else if (diff_Multiplier_Heroics.find(map->GetId()) == diff_Multiplier_Heroics.end())
+                {
                     return D10; //map not found returns the catch all value
                 }
                 else
                     return diff_Multiplier_Heroics[map->GetId()]; //return the specific dungeon's level
             }
-            if (diff_Multiplier.find(map->GetId()) == diff_Multiplier.end()) {
+            if (diff_Multiplier.find(map->GetId()) == diff_Multiplier.end())
+            {
                 //Catch Alls  ----------------------5 Dungeons and 40 Raids
-                if (map->IsDungeon()) {
+                if (map->IsDungeon())
+                {
                     return D5;
                 }
-                else if (map->IsRaid()) {
+                else if (map->IsRaid())
+                {
                     return D40;
                 }
             }
@@ -384,7 +390,8 @@ private:
         return 0; //return 0
     }
     // Set the Dungeon Level
-    int CalculateDungeonLevel(Map* map, Player* /*player*/) {
+    int CalculateDungeonLevel(Map* map, Player* /*player*/)
+    {
         if (dungeons.find(map->GetId()) == dungeons.end())
         {
             return SolocraftDungeonLevel; //map not found returns the catch all value
@@ -393,7 +400,8 @@ private:
             return dungeons[map->GetId()]; //return the specific dungeon's level
     }
     // Get the group's size
-    int GetNumInGroup(Player* player) {
+    int GetNumInGroup(Player* player)
+    {
         int numInGroup = 1;
         Group* group = player->GetGroup();
         if (group) {

--- a/src/server/scripts/Custom/Solocraft.cpp
+++ b/src/server/scripts/Custom/Solocraft.cpp
@@ -403,7 +403,8 @@ private:
         return numInGroup;
     }
     // Get the Player's class balance debuff
-    int GetClassBalance(Player* player) {
+    int GetClassBalance(Player* player)
+    {
         int classBalance = 100;
 
         if (classes.find(player->GetClass()) == classes.end())

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4134,7 +4134,7 @@ Solocraft.Enable = 1
 # Announce the module when the player logs in?
 Solocraft.Announce = 1
 ###################################################################################################
-#  Balancing - Groups (Overloading), Spellpower, and Stats
+#  Balancing - Groups (Overloading), Global Spellpower and Stats modifier, Global Class Balancing
 ###################################################################################################
 # Enable Debuff of new party members who enter the dungeon to avoid overloading the dungeon?
 # Overloading is when a group member already in the dungeon has the full offset/buff of the
@@ -4147,17 +4147,35 @@ Solocraft.Announce = 1
 SoloCraft.Debuff.Enable = 1
 # Spellpower Bonus Multiplier
 # Spellcasters spellpower bonus multiplier to offset no spellpower received from stats
-# Formula: (player->level * multiplier) * difficulty
+# Formula: (player->level * multiplier) * ((classBalance / 100) * difficulty)
 # Example Level 24 Mage with default modifier and  a dungeon difficulty of 5 will receive a base
 # Spellpower increase of 300.
 # Default:  2.5
 #           0.0 (Disable)
 SoloCraft.Spellpower.Mult = 2.5
 # Stats Percentage Bonus Multiplier
-# Forumla: player->Stats * (difficulty * multiplier)
+# Forumla: player->Stats * (((classBalance / 100) * difficulty) * multiplier)
 # Default:  100.0
 #           0.0 (Disable)
 SoloCraft.Stats.Mult = 100.0
+#
+# Class Balancing Modifier
+# This settings will only allow the percentage specified of the difficulty for the specified class
+# Example Level 24 Mage with default modifier (2.5), a dungeon difficulty of 5, and a 80 percent class
+# balance modifier will receive a base Spellpower increase of 240.
+# Note: 0 will completely disable the class from receiving difficulty modifiers from any dungeon
+#Default: 100 (Full Dungeon Difficulty Modifer will be Applied)
+#    	  0 (Disable) - 100
+SoloCraft.DEATH_KNIGHT = 100
+SoloCraft.DRUID = 100
+SoloCraft.HUNTER = 100
+SoloCraft.MAGE = 100
+SoloCraft.PALADIN = 100
+SoloCraft.PRIEST = 100
+SoloCraft.ROGUE = 100
+SoloCraft.SHAMAN = 100
+SoloCraft.WARLOCK = 100
+SoloCraft.WARRIOR = 100
 #
 ################################################################################################
 #Catch all Bucket - Difficulty Offset Defaults

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4165,7 +4165,7 @@ SoloCraft.Stats.Mult = 100.0
 # balance modifier will receive a base Spellpower increase of 240.
 # Note: 0 will completely disable the class from receiving difficulty modifiers from any dungeon
 #Default: 100 (Full Dungeon Difficulty Modifer will be Applied)
-#    	  0 (Disable) - 100
+#         0 (Disable) - 100
 SoloCraft.DEATH_KNIGHT = 100
 SoloCraft.DRUID = 100
 SoloCraft.HUNTER = 100


### PR DESCRIPTION
**Changes proposed**:
With class scaling you got the new configs to adjust the individual class to use a certain precentage of the established solocraft configs. Single value does not cover scaling perfectly, at times it will make select classes over power. Class configurations are adjustable INT between 0 to 100. Representing 0 for zero scaling for the individual class to 100 for full scaling of the individual class. It isnt a float so dont start using decimals for the Class Balancing Modifier

**Target branch(es)**: 335

**Issues addressed**: 

**Tests performed**: (Does it build, tested in-game, etc)
Builds and runs in game.

**Known issues and TODO list**:

- [ ] 
- [ ] 
