### PR TITLE
Update (passive anticheat): Monthly Anticheat Alignment

### DIFF
--- a/src/server/game/Anticheat/AnticheatMgr.cpp
+++ b/src/server/game/Anticheat/AnticheatMgr.cpp
@@ -19,6 +19,7 @@
 #include "AnticheatScripts.h"
 #include "AccountMgr.h"
 #include "DatabaseEnv.h"
+#include "Dbcstores.h"
 #include "Log.h"
 #include "Map.h"
 #include "MapManager.h"

--- a/src/server/game/Anticheat/AnticheatMgr.cpp
+++ b/src/server/game/Anticheat/AnticheatMgr.cpp
@@ -200,6 +200,10 @@ void AnticheatMgr::TeleportPlaneHackDetection(Player* player, MovementInfo movem
     if (!distance2D)
         return;
 
+    //Celestial Planetarium Observer Battle has a narrow path that false flags
+    if (player && GetWMOAreaTableEntryByTripple(5202, 0, 24083))
+        return;
+
     if (m_Players[key].GetLastOpcode() == MSG_MOVE_JUMP)
         return;
 
@@ -309,6 +313,10 @@ void AnticheatMgr::ZAxisHackDetection(Player* player, MovementInfo movementInfo)
    // If the player is allowed to waterwalk (or he is dead because he automatically waterwalks then) we dont need to check any further
    // We also stop if the player is in water, because otherwise you get a false positive for swimming
    if (movementInfo.HasMovementFlag(MOVEMENTFLAG_WATERWALKING) || player->IsInWater() || !player->IsAlive())
+       return;
+
+   //Celestial Planetarium Observer Battle has a narrow path that false flags
+   if (player && GetWMOAreaTableEntryByTripple(5202, 0, 24083))
        return;
 
    // We want to exclude this LiquidStatus from detection because it leads to false positives on boats, docks etc.

--- a/src/server/game/Anticheat/AnticheatMgr.cpp
+++ b/src/server/game/Anticheat/AnticheatMgr.cpp
@@ -19,7 +19,7 @@
 #include "AnticheatScripts.h"
 #include "AccountMgr.h"
 #include "DatabaseEnv.h"
-#include "Dbcstores.h"
+#include "DBCStores.h"
 #include "Log.h"
 #include "Map.h"
 #include "MapManager.h"


### PR DESCRIPTION
Not a whole lot of reports dealing with false positives since the last merge. So far this is the only issue as of right now dealing with exsisting cheat detections and false positives.

This is a unqiue one. the light path leading to the circle centeral area seems to be false hitting for ignore z axis and tele plane.
![image](https://user-images.githubusercontent.com/16887899/170885242-bda341bc-8e2b-483a-812b-00cc284eb146.png)

This is really the best solution I can come up with, since the map id is the whole instance and the zone and area id is the same, we lock it down to wmo area table entry by Tripple. 
![image](https://user-images.githubusercontent.com/16887899/170885309-f0608374-603e-4088-9b4a-58b12e13cbab.png)
![image](https://user-images.githubusercontent.com/16887899/170885348-a98aacd5-32d9-4c20-95d9-c159a8e16dba.png)

Doing any form of ignore z-axis or telepane would not benefit the player due to with the mechanics dealing with the battle with the observer, trash mobs fly and his attacks are a massive aoe.

**Changes proposed**:

- Exempt via wmo area table tripple.

**Target branch(es)**: 3.3.5-passive_anticheat

**Issues addressed**: Fixes # unreported false hits in Ulduan Celestial Planetarium

**Tests performed**: 
Builds and runs with no issues.
Area with the battle of observer has no false hits now.

**HOW TO TEST**:
.gm on
.go xyz 1632.95 -169.436 427.254 603 4.87
.additem 45796

Access the Celestial Planetarium console, proceed down the path when the door opens and see no more false hits.
