### PR TITLE
fix (SOLOCRAFT\DB): tinyint to int and mysql8 standard

### DIFF
--- a/sql/custom/characters/characters.solocraft.sql
+++ b/sql/custom/characters/characters.solocraft.sql
@@ -1,24 +1,9 @@
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET NAMES utf8 */;
-/*!50503 SET NAMES utf8mb4 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
-
--- Dumping structure for table characters.custom_solocraft_character_stats
 DROP TABLE IF EXISTS `custom_solocraft_character_stats`;
 CREATE TABLE IF NOT EXISTS `custom_solocraft_character_stats` (
-  `GUID` int unsigned NOT NULL DEFAULT 0,
+  `GUID` tinyint(3) unsigned NOT NULL,
   `Difficulty` float NOT NULL,
-  `GroupSize` int unsigned NOT NULL DEFAULT 0,
-  `SpellPower` int unsigned NOT NULL DEFAULT 0,
-  `Stats` float NOT NULL DEFAULT 100,
+  `GroupSize` int(11) NOT NULL,
+  `SpellPower` int(10) unsigned NOT NULL DEFAULT '0',
+  `Stats` float NOT NULL DEFAULT '100',
   PRIMARY KEY (`GUID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
-
--- Data exporting was unselected.
-
-/*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
-/*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40111 SET SQL_NOTES=IFNULL(@OLD_SQL_NOTES, 1) */;
+) ENGINE=InnoDB COLLATE='utf8mb4_general_ci';

--- a/sql/custom/characters/characters.solocraft.sql
+++ b/sql/custom/characters/characters.solocraft.sql
@@ -1,9 +1,9 @@
 DROP TABLE IF EXISTS `custom_solocraft_character_stats`;
 CREATE TABLE IF NOT EXISTS `custom_solocraft_character_stats` (
-  `GUID` tinyint(3) unsigned NOT NULL,
+  `GUID` int unsigned NOT NULL DEFAULT 0,
   `Difficulty` float NOT NULL,
-  `GroupSize` int(11) NOT NULL,
-  `SpellPower` int(10) unsigned NOT NULL DEFAULT '0',
+  `GroupSize` int unsigned NOT NULL DEFAULT 0,
+  `SpellPower` int unsigned NOT NULL DEFAULT 0,
   `Stats` float NOT NULL DEFAULT '100',
   PRIMARY KEY (`GUID`)
 ) ENGINE=InnoDB COLLATE='utf8mb4_general_ci';

--- a/sql/custom/characters/characters.solocraft.sql
+++ b/sql/custom/characters/characters.solocraft.sql
@@ -8,11 +8,11 @@
 -- Dumping structure for table characters.custom_solocraft_character_stats
 DROP TABLE IF EXISTS `custom_solocraft_character_stats`;
 CREATE TABLE IF NOT EXISTS `custom_solocraft_character_stats` (
-  `GUID` tinyint(3) unsigned NOT NULL,
+  `GUID` int unsigned NOT NULL DEFAULT 0,
   `Difficulty` float NOT NULL,
-  `GroupSize` int(11) NOT NULL,
-  `SpellPower` int(10) unsigned NOT NULL DEFAULT '0',
-  `Stats` float NOT NULL DEFAULT '100',
+  `GroupSize` int unsigned NOT NULL DEFAULT 0,
+  `SpellPower` int unsigned NOT NULL DEFAULT 0,
+  `Stats` float NOT NULL DEFAULT 100,
   PRIMARY KEY (`GUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 


### PR DESCRIPTION
- Closes https://github.com/TrinityCore/TrinityCoreCustomChanges/issues/75
Solution Provided by @qyh214 for issue https://github.com/TrinityCore/TrinityCoreCustomChanges/issues/75
Mysql8 formatting provided by @acidmanifesto 

**Changes proposed**:

- Change tinyint to int. for guid
- Update sql from depreciated to mysql8 standard.
- Adjusted formating to be compatible with MariaDB

**Target branch(es)**: 335-solocraft

**Issues addressed**: Fixes # https://github.com/TrinityCore/TrinityCoreCustomChanges/issues/75

**Tests performed**: (Does it build, tested in-game, etc)
No issues re-running sql.
No issues compiling.
Tested in game with no issues.

**Known issues and TODO list**:

- [ ] 
- [ ] 
