### PR TITLE
fix (module\skip dk): Optional Gossip and Quest Rewarded

### DIFF
--- a/src/server/scripts/Custom/SkipDK.cpp
+++ b/src/server/scripts/Custom/SkipDK.cpp
@@ -37,6 +37,10 @@
 #include "World.h"
 #include "WorldSession.h"
 
+constexpr auto OPTIONSKIPDK = 0;
+constexpr auto YESSKIPDK = 1;
+constexpr auto NOSKIPDK = 2;
+
 class Trinitycore_skip_deathknight_announce : public PlayerScript
 {
 public:
@@ -107,9 +111,15 @@ public:
                     player->RewardQuest(sObjectMgr->GetQuestTemplate(12801), false, player);
                 }
                 if (player->GetTeam() == ALLIANCE && player->GetQuestStatus(13188) == QUEST_STATUS_NONE)//Where Kings Walk
+                {
                     player->AddQuest(sObjectMgr->GetQuestTemplate(13188), nullptr);
+                    player->RewardQuest(sObjectMgr->GetQuestTemplate(13188), false, player);
+                }
                 else if (player->GetTeam() == HORDE && player->GetQuestStatus(13189) == QUEST_STATUS_NONE)//Saurfang's Blessing
+                {
                     player->AddQuest(sObjectMgr->GetQuestTemplate(13189), nullptr);
+                    player->RewardQuest(sObjectMgr->GetQuestTemplate(13189), false, player);
+                }
                 if (player->GetTeam() == ALLIANCE)
                     player->TeleportTo(0, -8833.37f, 628.62f, 94.00f, 1.06f);//Stormwind
                 else
@@ -165,9 +175,15 @@ public:
                     player->RewardQuest(sObjectMgr->GetQuestTemplate(12801), false, player);
                 }
                 if (player->GetTeam() == ALLIANCE && player->GetQuestStatus(13188) == QUEST_STATUS_NONE)//Where Kings Walk
+                {
                     player->AddQuest(sObjectMgr->GetQuestTemplate(13188), nullptr);
+                    player->RewardQuest(sObjectMgr->GetQuestTemplate(13188), false, player);
+                }
                 else if (player->GetTeam() == HORDE && player->GetQuestStatus(13189) == QUEST_STATUS_NONE)//Saurfang's Blessing
+                {
                     player->AddQuest(sObjectMgr->GetQuestTemplate(13189), nullptr);
+                    player->RewardQuest(sObjectMgr->GetQuestTemplate(13189), false, player);
+                }
                 if (player->GetTeam() == ALLIANCE)
                     player->TeleportTo(0, -8833.37f, 628.62f, 94.00f, 1.06f);//Stormwind
                 else
@@ -220,7 +236,7 @@ public:
                 case LOCALE_enUS: localizedEntry = LOCALE_LICHKING_0; break;
                 default: localizedEntry = LOCALE_LICHKING_0;
                 }
-                AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, localizedEntry, GOSSIP_SENDER_MAIN, 11);
+                AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, localizedEntry, GOSSIP_SENDER_MAIN, OPTIONSKIPDK);
             }
 
             player->TalkedToCreature(me->GetEntry(), me->GetGUID());
@@ -235,13 +251,13 @@ public:
 
             switch (gossipListId)
             {
-            case 11:
-                AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, "Yes", GOSSIP_SENDER_MAIN, 12);
-                AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, "No", GOSSIP_SENDER_MAIN, 13);
+            case OPTIONSKIPDK:
+                AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, "Yes", GOSSIP_SENDER_MAIN, YESSKIPDK);
+                AddGossipItemFor(player, GOSSIP_ICON_INTERACT_1, "No", GOSSIP_SENDER_MAIN, NOSKIPDK);
                 SendGossipMenuFor(player, player->GetGossipTextId(me), me->GetGUID());
                 break;
 
-            case 12:
+            case YESSKIPDK:
                 if (player->GetLevel() <= DKL)
                 {
                     player->SetLevel(DKL);
@@ -286,9 +302,15 @@ public:
                     player->RewardQuest(sObjectMgr->GetQuestTemplate(12801), false, player);
                 }
                 if (player->GetTeam() == ALLIANCE && player->GetQuestStatus(13188) == QUEST_STATUS_NONE)//Where Kings Walk
+                {
                     player->AddQuest(sObjectMgr->GetQuestTemplate(13188), nullptr);
+                    player->RewardQuest(sObjectMgr->GetQuestTemplate(13188), false, player);
+                }
                 else if (player->GetTeam() == HORDE && player->GetQuestStatus(13189) == QUEST_STATUS_NONE)//Saurfang's Blessing
+                {
                     player->AddQuest(sObjectMgr->GetQuestTemplate(13189), nullptr);
+                    player->RewardQuest(sObjectMgr->GetQuestTemplate(13189), false, player);
+                }
                 if (player->GetTeam() == ALLIANCE)
                     player->TeleportTo(0, -8833.37f, 628.62f, 94.00f, 1.06f);//Stormwind
                 else
@@ -297,7 +319,7 @@ public:
                 CloseGossipMenuFor(player);
                 break;
 
-            case 13://close
+            case NOSKIPDK://close
                 CloseGossipMenuFor(player);
                 break;
 

--- a/src/server/scripts/Custom/SkipDK.cpp
+++ b/src/server/scripts/Custom/SkipDK.cpp
@@ -248,7 +248,7 @@ public:
         {
             int DKL = sConfigMgr->GetFloatDefault("Skip.Deathknight.Start.Level", 58);
             CloseGossipMenuFor(player);
-
+            ClearGossipMenuFor(player);
             switch (gossipListId)
             {
             case OPTIONSKIPDK:


### PR DESCRIPTION
**Changes proposed**:

- This will correct the optional gossip no longer working. In debugger it kept going to case zero even thought it was designated case 11, not certain why so we do some constexpr auto to ensure it works specifically. 
- Final quests  Where Kings Walk Quest 13188 and  Saurfang's Blessing Quest 13189 are now auto completed as the quest being awarded with the item thru the module working but there was some issue with the quest when being awarded thru the module so we just reward it (autocompleted) to ensure that the skip dk module is now fully skipped 

**Target branch(es)**: 3.3.5-skip-dk

**Issues addressed**: Fixes # https://github.com/TrinityCore/TrinityCoreCustomChanges/issues/82

**Tests performed**: Build, Tested in game with optional gossip and auto skip options for player and gm.

**Known issues and TODO list**:

- [ ] 
- [ ] 
