### PR TITLE
update (SkipDK): Set default homebinds.

### DIFF
--- a/src/server/scripts/Custom/SkipDK.cpp
+++ b/src/server/scripts/Custom/SkipDK.cpp
@@ -112,7 +112,7 @@ void Trinitycore_skip_deathknight_HandleSkip(Player* player)
     player->SaveToDB();
 
     WorldLocation Aloc = WorldLocation(0, -8866.55f, 671.39f, 97.90f, 5.27f);// Stormwind
-    WorldLocation Hloc = WorldLocation(1, 1637.62f, -4440.22, 15.78f, 2.42f);// Orgrimmar
+    WorldLocation Hloc = WorldLocation(1, 1637.62f, -4440.22f, 15.78f, 2.42f);// Orgrimmar
 
     if (player->GetTeam() == ALLIANCE)
     {

--- a/src/server/scripts/Custom/SkipDK.cpp
+++ b/src/server/scripts/Custom/SkipDK.cpp
@@ -111,13 +111,18 @@ void Trinitycore_skip_deathknight_HandleSkip(Player* player)
     //Don't need to save all players, just current
     player->SaveToDB();
 
+    WorldLocation Aloc = WorldLocation(0, -8866.55f, 671.39f, 97.90f, 5.27f);// Stormwind
+    WorldLocation Hloc = WorldLocation(1, 1637.62f, -4440.22, 15.78f, 2.42f);// Orgrimmar
+
     if (player->GetTeam() == ALLIANCE)
     {
         player->TeleportTo(0, -8833.37f, 628.62f, 94.00f, 1.06f);//Stormwind
+        player->SetHomebind(Aloc, 1637);// Stormwind Homebind location
     }
     else
     {
         player->TeleportTo(1, 1569.59f, -4397.63f, 7.70f, 0.54f);//Orgrimmar
+        player->SetHomebind(Hloc, 1653);// Orgrimmar Homebind location
     }
 }
 


### PR DESCRIPTION
**Changes proposed**:

- Set default homebinds when module is used.

**Target branch(es)**: 335-skip-dk

**Issues addressed**: Fixes # Unreported Issue, No Default homebinds when used. If used players were sent to a unphased empty ebon hold until they used a death gate.

**Tests performed**: (Does it build, tested in-game, etc)
Builds
Tested in game

**Known issues and TODO list**:

- [ ] 
- [ ] 
