### PR TITLE
Fix wrong hook placement

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -1479,8 +1479,6 @@ void ScriptMgr::OnPlayerEnterMap(Map* map, Player* player)
 
     FOREACH_SCRIPT(PlayerScript)->OnMapChanged(player);
 
-    FOREACH_SCRIPT(AllMapScript)->OnPlayerLeaveAll(map, player);
-
     SCR_MAP_BGN(WorldMapScript, map, itr, end, entry, IsWorldMap);
         itr->second->OnPlayerEnter(map, player);
     SCR_MAP_END;
@@ -1498,6 +1496,8 @@ void ScriptMgr::OnPlayerLeaveMap(Map* map, Player* player)
 {
     ASSERT(map);
     ASSERT(player);
+
+    FOREACH_SCRIPT(AllMapScript)->OnPlayerLeaveAll(map, player);
 
     SCR_MAP_BGN(WorldMapScript, map, itr, end, entry, IsWorldMap);
         itr->second->OnPlayerLeave(map, player);


### PR DESCRIPTION
**Changes proposed**:

Both hooks, **enter and leave**, were executed in succession on the map that the player **enters**. As a result, they cancelled each other's effect. Basically when alone, player was [added to the map](https://github.com/TrinityCore/TrinityCoreCustomChanges/blob/1346832eb92d746850a7faae9e60a9221d91a559/src/server/scripts/Custom/autobalance.cpp#L366-L367) and [then removed instantly](https://github.com/TrinityCore/TrinityCoreCustomChanges/blob/1346832eb92d746850a7faae9e60a9221d91a559/src/server/scripts/Custom/autobalance.cpp#L404-L413) and it then resets the map level.

This PR moves OnPlayerLeaveAll hook from OnPlayerEnterMap to OnPlayerLeaveMap.
This makes the OnPlayerLeaveAll hook to be executed on the map that the player actually **leaves**.
According to the documentation it should be there.
```
         // Called when a player leave any Map
         virtual void OnPlayerLeaveAll(Map* /*map*/, Player* /*player*/) { }
```

**Target branch(es)**: 335/6x
3.3.5

**Issues addressed**:
Fixes https://github.com/TrinityCore/TrinityCoreCustomChanges/issues/91

**Tests performed**: (Does it build, tested in-game, etc)
- Builds
- Tested in game that NPCs now get their level set when entering dungeon alone

**Known issues and TODO list**:

